### PR TITLE
add note that script must run after dom element is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To create your doormat.
     </ol>
   ```
 
-3. Invoke the `Doormat` function passing in desired options(_explained below_) as a parameter;
+3. Invoke the `Doormat` function passing in desired options (_explained below_) as a parameter. Note this must run _after_ the object exists in the DOM (thus it won't work in the head).
 
   ```javascript
   var myDoormat = new Doormat();


### PR DESCRIPTION
At first I didn't realize that the elements have to be there - putting it in the head didn't work. So add to documentation.